### PR TITLE
Fix participation place scope picker visibiltiy

### DIFF
--- a/decidim-module-census_connector/app/assets/javascripts/decidim/census_connector/verifications/census.js.es6
+++ b/decidim-module-census_connector/app/assets/javascripts/decidim/census_connector/verifications/census.js.es6
@@ -27,7 +27,16 @@ $(() => {
           $scope.show();
         }
       }
-      toggleScope($("input[type=hidden]", $addressScope).val());
+
+      const $addressScopeValueField = $addressScope.find("input[type=hidden]");
+
+      let addressScopeId = null;
+
+      if ($addressScopeValueField.length > 0) {
+        addressScopeId = $addressScopeValueField.val();
+      }
+
+      toggleScope(addressScopeId);
       $addressScope.on("change", "input[type=hidden]", (event) => toggleScope($(event.target).val()));
     }
 

--- a/decidim-module-census_connector/spec/system/verifications/census_registration_spec.rb
+++ b/decidim-module-census_connector/spec/system/verifications/census_registration_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/core/test/factories"
+
+describe "Census registration", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+
+  let!(:inner_scope) { create(:scope, code: Decidim::CensusConnector.census_local_code, organization: organization) }
+  let!(:exterior_scope) { create(:scope, code: "XX", organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_census_account.root_path
+    click_link "Census"
+    click_link "Sign up to take part in votings"
+  end
+
+  it "asks for participation place only for exterior participants" do
+    expect(page).to have_no_content("Participation place")
+
+    scope_pick select_data_picker(:data_handler_address_scope_id), exterior_scope
+    expect(page).to have_content("Participation place")
+
+    scope_repick select_data_picker(:data_handler_address_scope_id), exterior_scope, inner_scope
+    expect(page).to have_no_content("Participation place")
+  end
+end


### PR DESCRIPTION
In order to overwhelm users with less fields, let's hide this field unless an abroad scope is selected.