### PR TITLE
First after login page

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,30 +1,19 @@
 # frozen_string_literal: true
 
-def main_organization
-  @main_organization ||= Decidim::Organization.first
-end
-
 def localize(text)
   { ca: text, es: text, eu: text, gl: text } # TO-DO: load translations
 end
 
-# Faker needs to have the `:en` locale in order to work properly, so we
-# must enforce it during the seeds.
 original_locales = I18n.available_locales
-I18n.available_locales = original_locales + [:en] unless original_locales.include?(:en)
-
-if !Rails.env.production? || ENV["SEED"]
-  Decidim::Core::Engine.load_seed
-  Decidim::CensusConnector::Engine.load_seed
-end
-
-Decidim::System::CreateDefaultPages.call(main_organization)
 
 base_path = File.expand_path("seeds/", __dir__)
 
-main_organization.update!(
+main_organization = Decidim::Organization.find_or_initialize_by(
   name: "Participa Podemos",
-  host: ENV["DECIDIM_HOST"] || "localhost",
+  host: ENV["DECIDIM_HOST"] || "localhost"
+)
+
+main_organization.update!(
   twitter_handler: "ahorapodemos",
   facebook_handler: "ahorapodemos",
   instagram_handler: "ahorapodemos",
@@ -46,6 +35,17 @@ main_organization.update!(
   reference_prefix: "POD",
   available_authorizations: Decidim.authorization_workflows.map(&:name)
 )
+
+# Faker needs to have the `:en` locale in order to work properly, so we
+# must enforce it during the seeds.
+I18n.available_locales = original_locales + [:en] unless original_locales.include?(:en)
+
+if !Rails.env.production? || ENV["SEED"]
+  Decidim::Core::Engine.load_seed
+  Decidim::CensusConnector::Engine.load_seed
+end
+
+Decidim::System::CreateDefaultPages.call(main_organization)
 
 assembly = Decidim::Assembly.create!(
   title: localize("Podemos Estatal"),

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,7 @@ end
 
 Decidim::System::CreateDefaultPages.call(main_organization)
 
-base_path ||= File.expand_path("seeds/", __dir__)
+base_path = File.expand_path("seeds/", __dir__)
 
 main_organization.update!(
   name: "Participa Podemos",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,7 @@ main_organization.update!(
   default_locale: Decidim.default_locale,
   available_locales: original_locales,
   reference_prefix: "POD",
-  available_authorizations: Decidim.authorization_workflows.map(&:name)
+  available_authorizations: ["census"]
 )
 
 # Faker needs to have the `:en` locale in order to work properly, so we

--- a/decidim-module-census_connector/config/locales/en.yml
+++ b/decidim-module-census_connector/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
           help:
           - People registered at Podemos census
       census:
+        explanation: Register at Podemos census to access the full functionality of Participa
         fields:
           age: Age
           document_type: Document type

--- a/decidim-module-census_connector/config/locales/es.yml
+++ b/decidim-module-census_connector/config/locales/es.yml
@@ -40,6 +40,7 @@ es:
           help:
           - Personas inscritas en el censo de Podemos
       census:
+        explanation: Regístrate en el censo de Podemos para acceder a toda la funcionalidad de Participa
         fields:
           age: Edad
           document_type: Tipo de documento


### PR DESCRIPTION
This PR includes a few improvements while investigating what happens after the first login. It improves the following:

* Make the "census" authorization the only workflow enabled in the sample organization, so the behavior is closer to the one we'll use.

* Adds a missing i18n key.

* Create the organization before `decidim` seeds. The change is very minor but it should be slightly faster since `decidim` skips creating the organization (and just picks the first one), if there's already one organization.

The conclusion is that after the first login, decidim takes the user to the authorizations page, which we want to remove, so that's a problem.

A first approach to hiding the "Authorizations" tab for https://github.com/podemos-info/decidim-module-census_connector/issues/4 could be:

* Override the `/authorizations` route in the main application routes file to redirect to the census page instead. This one I tried it and works fine.

* Hide the link with CSS. This one I'm not sure how to do it since the authorizations tab has no special classes or anything. I guess we have several options:

  * Hide it by "link number" with `nth-child` or something like that.
  * Override the view that renders the menu to skip it.
  * Hide it with JS.

But, maybe a better solution is to actually _keep_ the tab and move the "census" tab content there. I think if we add to decidim the posibility for authorization workflows to have a "show" page where more information about a granted organization can be displayed could be enough. Clicking on the census entry in the authorizations list would take you to this page, which would be the current "census account" page.

@leio10 What are your thoughts here?