### PR TITLE
Fix capistrano versioning conflict

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
-  gem "capistrano", "~> 3.6", require: false
+  gem "capistrano", "~> 3.11.0", require: false
   gem "capistrano-rails", "~> 1.3", require: false
   gem "capistrano-rvm", require: false
   gem "capistrano3-puma", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -779,7 +779,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   byebug
-  capistrano (~> 3.6)
+  capistrano (~> 3.11.0)
   capistrano-rails (~> 1.3)
   capistrano-rvm
   capistrano3-puma

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# config valid for current version and patch releases of Capistrano
-lock "~> 3.10.1"
-
 set :application, "participa2"
 set :repo_url, "git@github.com:podemos-info/participa2.git"
 


### PR DESCRIPTION
Last deploy failed, this should fix it. I'm unsure why `capistrano` provides this `lock` thing, it seems like doing `bundler`'s job.